### PR TITLE
Fix typo in en.json file

### DIFF
--- a/Web Server/htdocs/plugins/webapp_plugin/resources/json/locales/en.json
+++ b/Web Server/htdocs/plugins/webapp_plugin/resources/json/locales/en.json
@@ -1,5 +1,5 @@
 {
-   "webvi_plugin": {
+   "webapp_plugin": {
       "pluginTitle": "Web Application"
    }
 }


### PR DESCRIPTION
Confirmed that this fix causes the Web Application to appear correctly under Additional Applications. Without the change, it does not.

![Screen Shot 2020-01-14 at 11 05 18 AM](https://user-images.githubusercontent.com/1458528/72365432-d34d5180-36bd-11ea-8c2f-d81a128e93f8.png)
