### PR TITLE
Switch to NIAuthnRequirePrivilege in conf

### DIFF
--- a/Web Server/conf/conf.d/52_webapp_plugin.conf
+++ b/Web Server/conf/conf.d/52_webapp_plugin.conf
@@ -1,6 +1,5 @@
 <Directory htdocs/plugins/webapp_plugin>
     # Tell the privilege module to use webapp_plugin.htpriv
-	Session On
-    AuthNIPrivilegeApplication webapp_plugin
-    Require privilege ViewResource
+    Use NIAuthnEnableBrowsers
+    Use NIAuthnRequirePrivilege webapp_plugin ViewResource
 </Directory> 

--- a/Web Server/conf/htpriv.d/webapp_plugin.xml
+++ b/Web Server/conf/htpriv.d/webapp_plugin.xml
@@ -6,7 +6,7 @@
     <privileges> 
         <privilege id="ViewResource">
             <!-- Privileges can have multiple localized descriptions. -->
-            <description xml:lang="en">Allows viewing the resource</description>
+            <description xml:lang="en">Allows viewing the application</description>
 
             <!-- Default mappings for this privilege. -->
             <role id="everyone"/>

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 This repository contains a project created in LabVIEW NXG preconfigured to build a NIPKG that can be used to install a built WebVI application onto a SystemLink Server. The following instructions provide steps to install the NIPKG onto the a SystemLink server in the same manner that SystemLink server installs NIPKGs onto remote Windows and Linux Real-Time targets.
 
+**Note:** After installing an NIPKG built with LabVIEW NXG, the NI Web Server will need to be restarted for the changes to take effect.
+
 ### Configuring the SystemLink server for self deployment
 
 * Log into Windows on the SystemLink server machine
@@ -32,6 +34,9 @@ This repository contains a project created in LabVIEW NXG preconfigured to build
 * If not already complete add the feed containing the NIPKG to the System
 * Go to the **Available** software tab and find the WebVI build application. This example project uses the display name *SystemLink WebVI Plugin*.
 * Select install from the dropdown button in the same row as the application.
+
+  **Note:** The NI Web Server will need to be restarted for the changes to take effect.
+
 * Upon successful install navigate back to the SystemLink landing page which lists all installed applications.
 * Under **Additional Applications** you should see an application named **Web VI**. Clicking on this icon will load the WebVI application created in LabVIEW NXG.
 
@@ -87,15 +92,13 @@ To configure security/access control for all WebVIs in one place, modify the `52
  ```apache
 <Directory htdocs/plugins/webapp_plugin>
     # Tell the privilege module to use webapp_plugin.htpriv
-   Session On
-    AuthNIPrivilegeApplication webapp_plugin
-    Require privilege ViewResource
+    Use NIAuthnEnableBrowsers
+    Use NIAuthnRequirePrivilege webapp_plugin ViewResource
 </Directory>
 <Directory htdocs/plugins/webapp_plugin2>
     # Tell the privilege module to use webapp_plugin.htpriv
-   Session On
-    AuthNIPrivilegeApplication webapp_plugin
-    Require privilege ViewResource
+    Use NIAuthnEnableBrowsers
+    Use NIAuthnRequirePrivilege webapp_plugin ViewResource
 </Directory> ​
 ```
 
@@ -115,4 +118,8 @@ We use font awesome <http://fontawesome.io/icons/> by default for SWIF icons
 
 ### Copying the Plugin files to the Server
 
-Copy the `Web Server\htdocs` and `Web Server\conf` folders and files to your SystemLink web server (e.g. the NI Web Server)  `C:\Program Files\National Instruments\Shared\Web Server`. **Note** this step is not necessary if you are using NI Packages and SystemLink feeds to install the application on the SystemLink Server. See **Installing a Plugin Build in LabVIEW NXG**.
+Copy the `Web Server\htdocs` and `Web Server\conf` folders and files to your SystemLink web server (e.g. the NI Web Server)  `C:\Program Files\National Instruments\Shared\Web Server`.
+
+**Note:** This step is not necessary if you are using NI Packages and SystemLink feeds to install the application on the SystemLink Server. See **Installing a Plugin Built in LabVIEW NXG**.
+
+**Note:** The NI Web Server will need to be restarted for the changes to take effect.

--- a/webvi-systemlink-plugin/conf/conf.d/52_webvi_plugin.conf
+++ b/webvi-systemlink-plugin/conf/conf.d/52_webvi_plugin.conf
@@ -1,6 +1,5 @@
 <Directory htdocs/plugins/webvi_plugin>
     # Tell the privilege module to use webvi_plugin.htpriv
-    Session On
-    AuthNIPrivilegeApplication webvi_plugin
-    Require privilege ViewResource
+    Use NIAuthnEnableBrowsers
+    Use NIAuthnRequirePrivilege webvi_plugin ViewResource
 </Directory>

--- a/webvi-systemlink-plugin/conf/htpriv.d/webvi_plugin.xml
+++ b/webvi-systemlink-plugin/conf/htpriv.d/webvi_plugin.xml
@@ -6,7 +6,7 @@
     <privileges>
         <privilege id="ViewResource">
             <!-- Privileges can have multiple localized descriptions. -->
-            <description xml:lang="en">Allows viewing the resource</description>
+            <description xml:lang="en">Allows viewing the application</description>
 
             <!-- Default mappings for this privilege. -->
             <role id="everyone"/>


### PR DESCRIPTION
- Switched to the more modern approach for conf file configuration. In the future we should update the example to use [NIWebServerConfigurationCmd.exe and automatically restart the NI Web Server](https://github.com/ni/systemlink-web-interface-template/pull/5#discussion_r458845465).
- Adds notes to the README specifying that the NI Web Server needs to be restarted for changes to take effect.

Testing: Tested both the WebVI nipkg and Web Server workflows locally with a fairly recent 20.1 dev build.